### PR TITLE
fixed mapped devices not being discovered

### DIFF
--- a/pkg/utils/getpartitions.go
+++ b/pkg/utils/getpartitions.go
@@ -1,5 +1,5 @@
 /*
-Copyright © 2022 SUSE LLC
+Copyright © 2022 - 2023 SUSE LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -17,8 +17,12 @@ limitations under the License.
 package utils
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
+	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/jaypipes/ghw"
@@ -27,32 +31,80 @@ import (
 	v1 "github.com/rancher/elemental-cli/pkg/types/v1"
 )
 
-// ghwPartitionToInternalPartition transforms a block.Partition from ghw lib to our v1.Partition type
-func ghwPartitionToInternalPartition(partition *block.Partition) *v1.Partition {
-	return &v1.Partition{
-		FilesystemLabel: partition.FilesystemLabel,
-		Size:            uint(partition.SizeBytes / (1024 * 1024)), // Converts B to MB
-		Name:            partition.Name,
-		FS:              partition.Type,
-		Flags:           nil,
-		MountPoint:      partition.MountPoint,
-		Path:            filepath.Join("/dev", partition.Name),
-		Disk:            filepath.Join("/dev", partition.Disk.Name),
-	}
+const loopType = "loop"
+const cryptType = "crypto_LUKS"
+
+type BlockDevice struct {
+	Label      string `json:"label"`
+	PartLabel  string `json:"partlabel"`
+	MountPoint string `json:"mountpoint"`
+	Path       string `json:"path"`
+	Name       string `json:"name"`
+	Type       string `json:"type"`
+	Size       string `json:"fssize"`
+	FS         string `json:"fstype"`
+	PartFlags  string `json:"partflags"`
+	PKName     string `json:"pkname"`
+	Kname      string `json:"kname"`
+}
+
+type LsblkResponse struct {
+	BlockDevices []BlockDevice `json:"blockdevices"`
 }
 
 // GetAllPartitions returns all partitions in the system for all disks
 func GetAllPartitions() (v1.PartitionList, error) {
+	buf := bytes.NewBuffer(make([]byte, 0))
+	ebuff := bytes.NewBuffer(make([]byte, 0))
+
+	cmd := exec.Command("lsblk", "-aJOl")
+	cmd.Stdout = buf
+	cmd.Stderr = ebuff
+
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("%s:  %s", err, ebuff.String())
+	}
+
+	var blocks LsblkResponse
 	var parts []*v1.Partition
-	blockDevices, err := block.New(ghw.WithDisableTools(), ghw.WithDisableWarnings())
-	if err != nil {
+
+	if err := json.NewDecoder(buf).Decode(&blocks); err != nil {
 		return nil, err
 	}
-	for _, d := range blockDevices.Disks {
-		for _, part := range d.Partitions {
-			parts = append(parts, ghwPartitionToInternalPartition(part))
-		}
+
+	// map devices by kernel name for determining root later
+	deviceMap := make(map[string]BlockDevice, 0)
+	for _, device := range blocks.BlockDevices {
+		deviceMap[device.Kname] = device
 	}
+
+	for _, device := range blocks.BlockDevices {
+		// we explicitly ignore crypt and loop devices as they are likely backed by the actual device or partition
+		// we want to interact with.
+		if device.Type == loopType || device.FS == cryptType {
+			continue
+		}
+
+		// if a device is not the root kernel device walk the device tree to find the root
+		rootDisk := device
+		for rootDisk.PKName != "" {
+			rootDisk = deviceMap[rootDisk.PKName]
+		}
+
+		size, _ := strconv.Atoi(device.Size)
+
+		parts = append(parts, &v1.Partition{
+			Name:            device.PartLabel,
+			FilesystemLabel: device.Label,
+			Size:            uint(size / (1024 * 1024)),
+			FS:              device.FS,
+			Flags:           strings.Split(device.PartFlags, " "),
+			MountPoint:      device.MountPoint,
+			Path:            device.Path,
+			Disk:            rootDisk.Path,
+		})
+	}
+
 	return parts, nil
 }
 


### PR DESCRIPTION
PROBLEM:

The library that was previously being used to detect block devices did not include mapped devices. This meant that if a users were to have a custom disk layout some features such as reset would not work. For example if user were to set up their persistent partition with LUKS they would have a device mapped to the encrypted partition with the COS_PERSISTENT label. This worked fine for normal operations but caused issues with reset because reset would not see the labeled map device and fall back to the named partition. It would not recognize the filesystem and fail.

SOLUTION:

Rather than use the previous go library to detect block devices I switched to a subprocess call to lsblk. lsblk is able to list mapped devices allowing elemental to format the labeled mapper device rather that the partition it's self.