### PR TITLE
Find persistent on reset via udev data if its a devicemapper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ $(GINKGO):
 	@exit 1
 
 build:
-	go build -ldflags '$(LDFLAGS)' -o bin/elemental
+	CGO_ENABLED=0 go build -ldflags '$(LDFLAGS)' -o bin/elemental
 
 docker_build:
 	DOCKER_BUILDKIT=1 docker build --build-arg ELEMENTAL_VERSION=${GIT_TAG} --build-arg ELEMENTAL_COMMIT=${GIT_COMMIT} --target elemental -t elemental-cli:${GIT_TAG}-${GIT_COMMIT_SHORT} .

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -421,6 +421,12 @@ func NewResetSpec(cfg v1.Config) (*v1.ResetSpec, error) {
 		}
 		ep.Persistent.Name = constants.PersistentPartName
 	} else {
+		// We could have persistent encrypted which won't appear in ghw list
+		if ep.Persistent == nil {
+			ep.Persistent = utils.GetPersistentViaDM(cfg.Fs)
+		}
+	}
+	if ep.Persistent == nil {
 		cfg.Logger.Warnf("no Persistent partition found")
 	}
 


### PR DESCRIPTION
During reset if we need to identify persistent and that its a devicemapper, our usual methods wont work as ghw knows nothing about devicemappers.

This provides a workaround limited in scope to the reset action and if we have exhausted the other ways of getting the persistent partition and tries to iterate over all dm- devices and get their info from udev directly to match the label against the persistent label.