### PR TITLE
:sparkles: Add auth flags to upgrade command

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -188,3 +188,12 @@ func addSquashFsCompressionFlags(cmd *cobra.Command) {
 	cmd.Flags().StringArrayP("squash-compression", "x", []string{}, "cmd options for compression to pass to mksquashfs. Full cmd including --comp as the whole values will be passed to mksquashfs. For a full list of options please check mksquashfs manual. (default value: '-comp gzip -Xbcj ARCH')")
 	cmd.Flags().Bool("squash-no-compression", false, "Disable squashfs compression. Overrides any values on squash-compression")
 }
+
+func addAuthFlags(cmd *cobra.Command) {
+	cmd.Flags().String("auth-username", "", "Username to authenticate to registry/notary")
+	cmd.Flags().String("auth-password", "", "Password to authenticate to registry")
+	cmd.Flags().String("auth-type", "", "Auth type")
+	cmd.Flags().String("auth-server-address", "", "Authentication server address")
+	cmd.Flags().String("auth-identity-token", "", "Authentication identity token")
+	cmd.Flags().String("auth-registry-token", "", "Authentication registry token")
+}

--- a/cmd/pull-image.go
+++ b/cmd/pull-image.go
@@ -89,15 +89,10 @@ func NewPullImageCmd(root *cobra.Command, addCheckRoot bool) *cobra.Command {
 		},
 	}
 	root.AddCommand(c)
-	c.Flags().String("auth-username", "", "Username to authenticate to registry/notary")
-	c.Flags().String("auth-password", "", "Password to authenticate to registry")
-	c.Flags().String("auth-type", "", "Auth type")
-	c.Flags().String("auth-server-address", "", "Authentication server address")
-	c.Flags().String("auth-identity-token", "", "Authentication identity token")
-	c.Flags().String("auth-registry-token", "", "Authentication registry token")
 	c.Flags().Bool("verify", false, "Verify signed images to notary before to pull")
 	c.Flags().StringArray("plugin", []string{}, "A list of runtime plugins to load. Can be repeated to add more than one plugin")
 	addLocalImageFlag(c)
+	addAuthFlags(c)
 	return c
 }
 

--- a/elemental.md
+++ b/elemental.md
@@ -1,0 +1,27 @@
+## elemental
+
+Elemental
+
+### Options
+
+```
+      --config-dir string   Set config dir (default is /etc/elemental) (default "/etc/elemental")
+      --debug               Enable debug output
+  -h, --help                help for elemental
+      --logfile string      Set logfile
+      --quiet               Do not output to stdout
+```
+
+### SEE ALSO
+
+* [elemental build-disk](elemental_build-disk.md)	 - Build a raw recovery image
+* [elemental build-iso](elemental_build-iso.md)	 - Build bootable installation media ISOs
+* [elemental cloud-init](elemental_cloud-init.md)	 - Run cloud-init
+* [elemental convert-disk](elemental_convert-disk.md)	 - converts between a raw disk and a cloud operator disk image (azure,gce)
+* [elemental install](elemental_install.md)	 - Elemental installer
+* [elemental pull-image](elemental_pull-image.md)	 - Pull remote image to local file
+* [elemental reset](elemental_reset.md)	 - Reset OS
+* [elemental run-stage](elemental_run-stage.md)	 - Run stage from cloud-init
+* [elemental upgrade](elemental_upgrade.md)	 - Upgrade the system
+* [elemental version](elemental_version.md)	 - Print the version
+

--- a/elemental_build-disk.md
+++ b/elemental_build-disk.md
@@ -1,0 +1,34 @@
+## elemental build-disk
+
+Build a raw recovery image
+
+```
+elemental build-disk [flags]
+```
+
+### Options
+
+```
+  -a, --arch string             Arch to build the image for (default "x86_64")
+      --cosign                  Enable cosign verification (requires images with signatures)
+      --cosign-key string       Sets the URL of the public key to be used by cosign validation
+  -h, --help                    help for build-disk
+      --oem_label string        Oem partition label (default "COS_OEM")
+  -o, --output string           Output file (Extension auto changes based of the image type) (default "disk.raw")
+      --recovery_label string   Recovery partition label (default "COS_RECOVERY")
+  -t, --type string             Type of image to create (default "raw")
+```
+
+### Options inherited from parent commands
+
+```
+      --config-dir string   Set config dir (default is /etc/elemental) (default "/etc/elemental")
+      --debug               Enable debug output
+      --logfile string      Set logfile
+      --quiet               Do not output to stdout
+```
+
+### SEE ALSO
+
+* [elemental](elemental.md)	 - Elemental
+

--- a/elemental_build-iso.md
+++ b/elemental_build-iso.md
@@ -1,0 +1,50 @@
+## elemental build-iso
+
+Build bootable installation media ISOs
+
+### Synopsis
+
+Build bootable installation media ISOs
+
+SOURCE - should be provided as uri in following format <sourceType>:<sourceName>
+    * <sourceType> - might be ["dir", "file", "oci", "docker", "channel"], as default is "docker"
+    * <sourceName> - is path to file or directory, image name with tag version or channel name
+
+```
+elemental build-iso SOURCE [flags]
+```
+
+### Options
+
+```
+  -a, --arch string                      Arch to build the image for (default "x86_64")
+      --bootloader-in-rootfs             Fetch ISO bootloader binaries from the rootfs
+      --cosign                           Enable cosign verification (requires images with signatures)
+      --cosign-key string                Sets the URL of the public key to be used by cosign validation
+      --date                             Adds a date suffix into the generated ISO file
+  -h, --help                             help for build-iso
+      --label string                     Label of the ISO volume
+      --local                            Use an image from local cache
+  -n, --name string                      Basename of the generated ISO file
+  -o, --output string                    Output directory (defaults to current directory)
+      --overlay-iso string               Path of the overlayed iso data
+      --overlay-rootfs string            Path of the overlayed rootfs data
+      --overlay-uefi string              Path of the overlayed uefi data
+      --repo stringArray                 A repository URI for luet. Can be repeated to add more than one source.
+  -x, --squash-compression stringArray   cmd options for compression to pass to mksquashfs. Full cmd including --comp as the whole values will be passed to mksquashfs. For a full list of options please check mksquashfs manual. (default value: '-comp gzip -Xbcj ARCH')
+      --squash-no-compression            Disable squashfs compression. Overrides any values on squash-compression
+```
+
+### Options inherited from parent commands
+
+```
+      --config-dir string   Set config dir (default is /etc/elemental) (default "/etc/elemental")
+      --debug               Enable debug output
+      --logfile string      Set logfile
+      --quiet               Do not output to stdout
+```
+
+### SEE ALSO
+
+* [elemental](elemental.md)	 - Elemental
+

--- a/elemental_cloud-init.md
+++ b/elemental_cloud-init.md
@@ -1,0 +1,29 @@
+## elemental cloud-init
+
+Run cloud-init
+
+```
+elemental cloud-init [flags]
+```
+
+### Options
+
+```
+  -d, --dotnotation stages.foo.name=..   Parse input in dotnotation ( e.g. stages.foo.name=.. ) 
+  -h, --help                             help for cloud-init
+  -s, --stage string                     Stage to apply (default "default")
+```
+
+### Options inherited from parent commands
+
+```
+      --config-dir string   Set config dir (default is /etc/elemental) (default "/etc/elemental")
+      --debug               Enable debug output
+      --logfile string      Set logfile
+      --quiet               Do not output to stdout
+```
+
+### SEE ALSO
+
+* [elemental](elemental.md)	 - Elemental
+

--- a/elemental_convert-disk.md
+++ b/elemental_convert-disk.md
@@ -1,0 +1,29 @@
+## elemental convert-disk
+
+converts between a raw disk and a cloud operator disk image (azure,gce)
+
+```
+elemental convert-disk RAW_DISK [flags]
+```
+
+### Options
+
+```
+  -h, --help          help for convert-disk
+      --keep-source   Keep the source image, otherwise it will delete it once transformed.
+  -t, --type string   Type of image to create (default "azure")
+```
+
+### Options inherited from parent commands
+
+```
+      --config-dir string   Set config dir (default is /etc/elemental) (default "/etc/elemental")
+      --debug               Enable debug output
+      --logfile string      Set logfile
+      --quiet               Do not output to stdout
+```
+
+### SEE ALSO
+
+* [elemental](elemental.md)	 - Elemental
+

--- a/elemental_install.md
+++ b/elemental_install.md
@@ -1,0 +1,46 @@
+## elemental install
+
+Elemental installer
+
+```
+elemental install DEVICE [flags]
+```
+
+### Options
+
+```
+  -c, --cloud-init strings               Cloud-init config files
+      --cosign                           Enable cosign verification (requires images with signatures)
+      --cosign-key string                Sets the URL of the public key to be used by cosign validation
+      --eject-cd                         Try to eject the cd on reboot, only valid if booting from iso
+      --firmware string                  Firmware to install for ('esp' or 'bios') (default "efi")
+      --force                            Force install
+  -h, --help                             help for install
+  -i, --iso string                       Performs an installation from the ISO url
+      --local                            Use an image from local cache
+      --no-format                        Don’t format disks. It is implied that COS_STATE, COS_RECOVERY, COS_PERSISTENT, COS_OEM are already existing
+      --part-table string                Partition table type to use (default "gpt")
+      --poweroff                         Shutdown the system after install
+      --reboot                           Reboot the system after install
+      --recovery-system.uri string       Sets the recovery image source and its type (e.g. 'docker:registry.org/image:tag')
+  -x, --squash-compression stringArray   cmd options for compression to pass to mksquashfs. Full cmd including --comp as the whole values will be passed to mksquashfs. For a full list of options please check mksquashfs manual. (default value: '-comp gzip -Xbcj ARCH')
+      --squash-no-compression            Disable squashfs compression. Overrides any values on squash-compression
+      --strict                           Enable strict check of hooks (They need to exit with 0)
+      --system.uri string                Sets the system image source and its type (e.g. 'docker:registry.org/image:tag')
+      --tty string                       Add named tty to grub
+      --verify                           Enable mtree checksum verification (requires images manifests generated with mtree separately)
+```
+
+### Options inherited from parent commands
+
+```
+      --config-dir string   Set config dir (default is /etc/elemental) (default "/etc/elemental")
+      --debug               Enable debug output
+      --logfile string      Set logfile
+      --quiet               Do not output to stdout
+```
+
+### SEE ALSO
+
+* [elemental](elemental.md)	 - Elemental
+

--- a/elemental_pull-image.md
+++ b/elemental_pull-image.md
@@ -1,0 +1,36 @@
+## elemental pull-image
+
+Pull remote image to local file
+
+```
+elemental pull-image IMAGE DESTINATION [flags]
+```
+
+### Options
+
+```
+      --auth-identity-token string   Authentication identity token
+      --auth-password string         Password to authenticate to registry
+      --auth-registry-token string   Authentication registry token
+      --auth-server-address string   Authentication server address
+      --auth-type string             Auth type
+      --auth-username string         Username to authenticate to registry/notary
+  -h, --help                         help for pull-image
+      --local                        Use an image from local cache
+      --plugin stringArray           A list of runtime plugins to load. Can be repeated to add more than one plugin
+      --verify                       Verify signed images to notary before to pull
+```
+
+### Options inherited from parent commands
+
+```
+      --config-dir string   Set config dir (default is /etc/elemental) (default "/etc/elemental")
+      --debug               Enable debug output
+      --logfile string      Set logfile
+      --quiet               Do not output to stdout
+```
+
+### SEE ALSO
+
+* [elemental](elemental.md)	 - Elemental
+

--- a/elemental_reset.md
+++ b/elemental_reset.md
@@ -1,0 +1,37 @@
+## elemental reset
+
+Reset OS
+
+```
+elemental reset [flags]
+```
+
+### Options
+
+```
+      --cosign              Enable cosign verification (requires images with signatures)
+      --cosign-key string   Sets the URL of the public key to be used by cosign validation
+  -h, --help                help for reset
+      --poweroff            Shutdown the system after install
+      --reboot              Reboot the system after install
+      --reset-oem           Clear OEM partitions
+      --reset-persistent    Clear persistent partitions
+      --strict              Enable strict check of hooks (They need to exit with 0)
+      --system.uri string   Sets the system image source and its type (e.g. 'docker:registry.org/image:tag')
+      --tty                 Add named tty to grub
+      --verify              Enable mtree checksum verification (requires images manifests generated with mtree separately)
+```
+
+### Options inherited from parent commands
+
+```
+      --config-dir string   Set config dir (default is /etc/elemental) (default "/etc/elemental")
+      --debug               Enable debug output
+      --logfile string      Set logfile
+      --quiet               Do not output to stdout
+```
+
+### SEE ALSO
+
+* [elemental](elemental.md)	 - Elemental
+

--- a/elemental_run-stage.md
+++ b/elemental_run-stage.md
@@ -1,0 +1,28 @@
+## elemental run-stage
+
+Run stage from cloud-init
+
+```
+elemental run-stage STAGE [flags]
+```
+
+### Options
+
+```
+  -h, --help     help for run-stage
+      --strict   Set strict checking for errors, i.e. fail if errors were found
+```
+
+### Options inherited from parent commands
+
+```
+      --config-dir string   Set config dir (default is /etc/elemental) (default "/etc/elemental")
+      --debug               Enable debug output
+      --logfile string      Set logfile
+      --quiet               Do not output to stdout
+```
+
+### SEE ALSO
+
+* [elemental](elemental.md)	 - Elemental
+

--- a/elemental_upgrade.md
+++ b/elemental_upgrade.md
@@ -1,0 +1,45 @@
+## elemental upgrade
+
+Upgrade the system
+
+```
+elemental upgrade [flags]
+```
+
+### Options
+
+```
+      --auth-identity-token string       Authentication identity token
+      --auth-password string             Password to authenticate to registry
+      --auth-registry-token string       Authentication registry token
+      --auth-server-address string       Authentication server address
+      --auth-type string                 Auth type
+      --auth-username string             Username to authenticate to registry/notary
+      --cosign                           Enable cosign verification (requires images with signatures)
+      --cosign-key string                Sets the URL of the public key to be used by cosign validation
+  -h, --help                             help for upgrade
+      --local                            Use an image from local cache
+      --poweroff                         Shutdown the system after install
+      --reboot                           Reboot the system after install
+      --recovery                         Upgrade the recovery
+      --recovery-system.uri string       Sets the recovery image source and its type (e.g. 'docker:registry.org/image:tag')
+  -x, --squash-compression stringArray   cmd options for compression to pass to mksquashfs. Full cmd including --comp as the whole values will be passed to mksquashfs. For a full list of options please check mksquashfs manual. (default value: '-comp gzip -Xbcj ARCH')
+      --squash-no-compression            Disable squashfs compression. Overrides any values on squash-compression
+      --strict                           Enable strict check of hooks (They need to exit with 0)
+      --system.uri string                Sets the system image source and its type (e.g. 'docker:registry.org/image:tag')
+      --verify                           Enable mtree checksum verification (requires images manifests generated with mtree separately)
+```
+
+### Options inherited from parent commands
+
+```
+      --config-dir string   Set config dir (default is /etc/elemental) (default "/etc/elemental")
+      --debug               Enable debug output
+      --logfile string      Set logfile
+      --quiet               Do not output to stdout
+```
+
+### SEE ALSO
+
+* [elemental](elemental.md)	 - Elemental
+

--- a/elemental_version.md
+++ b/elemental_version.md
@@ -1,0 +1,28 @@
+## elemental version
+
+Print the version
+
+```
+elemental version [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for version
+      --long   Show long version info
+```
+
+### Options inherited from parent commands
+
+```
+      --config-dir string   Set config dir (default is /etc/elemental) (default "/etc/elemental")
+      --debug               Enable debug output
+      --logfile string      Set logfile
+      --quiet               Do not output to stdout
+```
+
+### SEE ALSO
+
+* [elemental](elemental.md)	 - Elemental
+


### PR DESCRIPTION
There were no auth flags for docker repos in the upgrade command, which made it not possible to upgrade from private repos unless you first pulled the image.

This adds the same flags as the pull-image command so at least you can pass some auth to the upgrade