### PR TITLE
Fix shim name

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -126,7 +126,7 @@ const (
 	ArchAmd64  = "amd64"
 	Archx86    = "x86_64"
 	ArchArm64  = "arm64"
-	SignedShim = "shim-susesigned.efi"
+	SignedShim = "shim.efi"
 )
 
 func GetCloudInitPaths() []string {


### PR DESCRIPTION
Shim changed name when the grub2-efi packages had a different package installed (shim-susesigned vs shim) and that resulted in a different name for the shim file.

Package was updated by elemental-cli was not, so once we updated the package on kairos, this resulted in a broken install.

Fix it by setting the old good name as shown in the package contents (system/grub2-efi)